### PR TITLE
Added RFC-4733 DTMF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Child components get access to this context:
   answerCall: PropTypes.func,
   startCall: PropTypes.func,
   stopCall: PropTypes.func,
+  sendDTMF: PropTypes.func,
 }
 ```
 
@@ -119,6 +120,12 @@ To make calls, simply use these functions:
 
 The value for `destination` argument equals to the target SIP user without the host part (e.g. `+441234567890` or `bob`).
 The omitted host part is equal to host you’ve defined in `SipProvider` props (e.g. `sip.example.com`).
+
+To send DTMF tones while in-call, you can use this function:
+
+`sendDTMF(value)`
+
+The DTMF implementation is **not** SIP INFO, but [RFC-4733](https://tools.ietf.org/html/rfc4733).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,10 @@ The omitted host part is equal to host you’ve defined in `SipProvider` props (
 
 To send DTMF tones while in-call, you can use this function:
 
-`sendDTMF(value)`
+`sendDTMF(tones)`
+
+You can pass as many tones as you want in a `string` (e.g. `sendDTMF("1234")`).  
+You may also specify `duration` and `interToneGap` in milliseconds, as `sendDTMF("1234", 100, 70)`. See [the MDN docs for `RTCDTMFSender.insertDTMF()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCDTMFSender/insertDTMF) for further details.
 
 The DTMF implementation is **not** SIP INFO, but [RFC-4733](https://tools.ietf.org/html/rfc4733).
 

--- a/src/components/SipProvider/index.ts
+++ b/src/components/SipProvider/index.ts
@@ -55,6 +55,7 @@ export default class SipProvider extends React.Component<
     callStatus: CallStatus;
     callDirection: CallDirection | null;
     callCounterpart: string | null;
+    dtmfSender: RTCDTMFSender | null;
     rtcSession;
   }
 > {
@@ -67,6 +68,7 @@ export default class SipProvider extends React.Component<
     answerCall: PropTypes.func,
     startCall: PropTypes.func,
     stopCall: PropTypes.func,
+    sendDTMF: PropTypes.func,
   };
 
   public static propTypes = {
@@ -119,6 +121,7 @@ export default class SipProvider extends React.Component<
       callStatus: CALL_STATUS_IDLE,
       callDirection: null,
       callCounterpart: null,
+      dtmfSender: null,
     };
 
     this.ua = null;
@@ -137,6 +140,7 @@ export default class SipProvider extends React.Component<
         status: this.state.callStatus,
         direction: this.state.callDirection,
         counterpart: this.state.callCounterpart,
+        dtmfSender: this.state.dtmfSender,
       },
       registerSip: this.registerSip,
       unregisterSip: this.unregisterSip,
@@ -144,6 +148,7 @@ export default class SipProvider extends React.Component<
       answerCall: this.answerCall,
       startCall: this.startCall,
       stopCall: this.stopCall,
+      sendDTMF: this.sendDTMF,
     };
   }
 
@@ -289,6 +294,15 @@ export default class SipProvider extends React.Component<
   public stopCall = () => {
     this.setState({ callStatus: CALL_STATUS_STOPPING });
     this.ua.terminateSessions();
+  };
+
+  public sendDTMF = ( value ) => {
+    if( this.state.callStatus === "callStatus/ACTIVE" && this.state.dtmfSender ) {
+      this.state.dtmfSender.insertDTMF(value);
+    }
+    else {
+      this.logger.debug("Warning:", "You are attempting to send DTMF, but there is no active call.")
+    }
   };
 
   public reconfigureDebug() {
@@ -471,6 +485,7 @@ export default class SipProvider extends React.Component<
             callStatus: CALL_STATUS_IDLE,
             callDirection: null,
             callCounterpart: null,
+            dtmfSender: null,
           });
         });
 
@@ -484,6 +499,7 @@ export default class SipProvider extends React.Component<
             callStatus: CALL_STATUS_IDLE,
             callDirection: null,
             callCounterpart: null,
+            dtmfSender: null,
           });
         });
 
@@ -495,6 +511,10 @@ export default class SipProvider extends React.Component<
           [
             this.remoteAudio.srcObject,
           ] = rtcSession.connection.getRemoteStreams();
+
+          // Set up DTMF
+          this.setState({dtmfSender: rtcSession.connection.getSenders()[0].dtmf});
+
           // const played = this.remoteAudio.play();
           const played = this.remoteAudio.play();
 
@@ -508,6 +528,7 @@ export default class SipProvider extends React.Component<
                   this.remoteAudio.play();
                 }, 2000);
               });
+            // this.setState({ dtmfSender: rtcSession.connection.createDTMFSender(rtcSession.getAudioTracks()[0])});
             this.setState({ callStatus: CALL_STATUS_ACTIVE });
             return;
           }

--- a/src/components/SipProvider/index.ts
+++ b/src/components/SipProvider/index.ts
@@ -499,6 +499,11 @@ export default class SipProvider extends React.Component<
             return;
           }
 
+          // Close senders, as these keep the microphone open according to browsers (and that keeps Bluetooth headphones from exiting headset mode)
+          this.state.rtcSession.connection.getSenders().forEach((sender) => {
+            sender.track.stop();
+          });
+
           this.setState({
             rtcSession: null,
             callStatus: CALL_STATUS_IDLE,

--- a/src/components/SipProvider/index.ts
+++ b/src/components/SipProvider/index.ts
@@ -296,12 +296,17 @@ export default class SipProvider extends React.Component<
     this.ua.terminateSessions();
   };
 
-  public sendDTMF = ( value ) => {
-    if( this.state.callStatus === "callStatus/ACTIVE" && this.state.dtmfSender ) {
+  public sendDTMF = (value) => {
+    if (
+      this.state.callStatus === "callStatus/ACTIVE" &&
+      this.state.dtmfSender
+    ) {
       this.state.dtmfSender.insertDTMF(value);
-    }
-    else {
-      this.logger.debug("Warning:", "You are attempting to send DTMF, but there is no active call.")
+    } else {
+      this.logger.debug(
+        "Warning:",
+        "You are attempting to send DTMF, but there is no active call.",
+      );
     }
   };
 
@@ -513,7 +518,9 @@ export default class SipProvider extends React.Component<
           ] = rtcSession.connection.getRemoteStreams();
 
           // Set up DTMF
-          this.setState({dtmfSender: rtcSession.connection.getSenders()[0].dtmf});
+          this.setState({
+            dtmfSender: rtcSession.connection.getSenders()[0].dtmf,
+          });
 
           // const played = this.remoteAudio.play();
           const played = this.remoteAudio.play();

--- a/src/components/SipProvider/index.ts
+++ b/src/components/SipProvider/index.ts
@@ -296,12 +296,12 @@ export default class SipProvider extends React.Component<
     this.ua.terminateSessions();
   };
 
-  public sendDTMF = (value) => {
+  public sendDTMF = (tones, duration = 100, interToneGap = 70) => {
     if (
       this.state.callStatus === "callStatus/ACTIVE" &&
       this.state.dtmfSender
     ) {
-      this.state.dtmfSender.insertDTMF(value);
+      this.state.dtmfSender.insertDTMF(tones, duration, interToneGap);
     } else {
       this.logger.debug(
         "Warning:",


### PR DESCRIPTION
We're using react-sip for a project at our organization, and we needed DTMF support, so I took the liberty of adding it to react-sip.

Note that this is RFC-4733 DTMF, so DTMF in the RTP payload, rather than JsSip's SIP INFO implementation. This could be added, but doesn't fit our specific use case as we connect to PSTN providers who don't support SIP INFO (and therefore I won't be allocated time to do it 😞).