### PR TITLE
Added the ability to choose a specific audio device

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ ReactDOM.render(
       { urls: 'turn:example.com', username: 'foo', credential: '1234' }
     ]}
     debug={false} // whether to output events to console; false by default
+    incomingAudioDeviceId={"default"} // default, or a deviceId obtained from navigator.mediaDevices.enumerateDevices()
+    outboundAudioDeviceId={"default"} // default, or a deviceId obtained from navigator.mediaDevices.enumerateDevices()
   >
     <App />
   </SipProvider>

--- a/src/components/SipProvider/index.ts
+++ b/src/components/SipProvider/index.ts
@@ -164,9 +164,6 @@ export default class SipProvider extends React.Component<
 
     this.remoteAudio = window.document.createElement("audio");
     this.remoteAudio.id = "sip-provider-audio";
-    if (this.props.incomingAudioDeviceId) {
-      this.remoteAudio.setSinkId(this.props.incomingAudioDeviceId);
-    }
     window.document.body.appendChild(this.remoteAudio);
 
     this.reconfigureDebug();
@@ -183,7 +180,9 @@ export default class SipProvider extends React.Component<
       this.props.pathname !== prevProps.pathname ||
       this.props.user !== prevProps.user ||
       this.props.password !== prevProps.password ||
-      this.props.autoRegister !== prevProps.autoRegister
+      this.props.autoRegister !== prevProps.autoRegister ||
+      this.props.incomingAudioDeviceId !== prevProps.incomingAudioDeviceId ||
+      this.props.outboundAudioDeviceId !== prevProps.outboundAudioDeviceId
     ) {
       this.reinitializeJsSIP();
     }
@@ -318,7 +317,16 @@ export default class SipProvider extends React.Component<
       this.ua = null;
     }
 
-    const { host, port, pathname, user, password, autoRegister } = this.props;
+    const {
+      host,
+      port,
+      pathname,
+      user,
+      password,
+      autoRegister,
+      incomingAudioDeviceId,
+      outboundAudioDeviceId,
+    } = this.props;
 
     if (!host || !port || !user) {
       this.setState({
@@ -327,6 +335,10 @@ export default class SipProvider extends React.Component<
         sipErrorMessage: null,
       });
       return;
+    }
+
+    if (incomingAudioDeviceId) {
+      this.remoteAudio.setSinkId(incomingAudioDeviceId);
     }
 
     try {
@@ -475,6 +487,8 @@ export default class SipProvider extends React.Component<
             return;
           }
 
+          this.remoteAudio.srcObject = null;
+
           this.setState({
             rtcSession: null,
             callStatus: CALL_STATUS_IDLE,
@@ -487,6 +501,8 @@ export default class SipProvider extends React.Component<
           if (this.ua !== ua) {
             return;
           }
+
+          this.remoteAudio.srcObject = null;
 
           this.setState({
             rtcSession: null,
@@ -502,12 +518,12 @@ export default class SipProvider extends React.Component<
           }
 
           // Set outbound device, if provided
-          if (this.props.outboundAudioDeviceId) {
+          if (outboundAudioDeviceId) {
             // Get the appropriate device and set the new stream
             const constraints = {
               audio: {
                 deviceId: {
-                  exact: this.props.outboundAudioDeviceId,
+                  exact: outboundAudioDeviceId,
                 },
               },
             };

--- a/src/components/SipProvider/index.ts
+++ b/src/components/SipProvider/index.ts
@@ -296,6 +296,12 @@ export default class SipProvider extends React.Component<
 
   public stopCall = () => {
     this.setState({ callStatus: CALL_STATUS_STOPPING });
+
+    // Close senders, as these keep the microphone open according to browsers (and that keeps Bluetooth headphones from exiting headset mode)
+    this.state.rtcSession.connection.getSenders().forEach((sender) => {
+      sender.track.stop();
+    });
+
     this.ua.terminateSessions();
   };
 
@@ -487,8 +493,6 @@ export default class SipProvider extends React.Component<
             return;
           }
 
-          this.remoteAudio.srcObject = null;
-
           this.setState({
             rtcSession: null,
             callStatus: CALL_STATUS_IDLE,
@@ -501,8 +505,6 @@ export default class SipProvider extends React.Component<
           if (this.ua !== ua) {
             return;
           }
-
-          this.remoteAudio.srcObject = null;
 
           this.setState({
             rtcSession: null,

--- a/src/components/SipProvider/index.ts
+++ b/src/components/SipProvider/index.ts
@@ -296,14 +296,6 @@ export default class SipProvider extends React.Component<
 
   public stopCall = () => {
     this.setState({ callStatus: CALL_STATUS_STOPPING });
-
-    if (this.state.rtcSession.connection) {
-      // Close senders, as these keep the microphone open according to browsers (and that keeps Bluetooth headphones from exiting headset mode)
-      this.state.rtcSession.connection.getSenders().forEach((sender) => {
-        sender.track.stop();
-      });
-    }
-
     this.ua.terminateSessions();
   };
 
@@ -495,6 +487,13 @@ export default class SipProvider extends React.Component<
             return;
           }
 
+          if (this.state.rtcSession.connection) {
+            // Close senders, as these keep the microphone open according to browsers (and that keeps Bluetooth headphones from exiting headset mode)
+            this.state.rtcSession.connection.getSenders().forEach((sender) => {
+              sender.track.stop();
+            });
+          }
+
           this.setState({
             rtcSession: null,
             callStatus: CALL_STATUS_IDLE,
@@ -506,6 +505,13 @@ export default class SipProvider extends React.Component<
         rtcSession.on("ended", () => {
           if (this.ua !== ua) {
             return;
+          }
+
+          if (this.state.rtcSession.connection) {
+            // Close senders, as these keep the microphone open according to browsers (and that keeps Bluetooth headphones from exiting headset mode)
+            this.state.rtcSession.connection.getSenders().forEach((sender) => {
+              sender.track.stop();
+            });
           }
 
           this.setState({

--- a/src/components/SipProvider/index.ts
+++ b/src/components/SipProvider/index.ts
@@ -297,10 +297,12 @@ export default class SipProvider extends React.Component<
   public stopCall = () => {
     this.setState({ callStatus: CALL_STATUS_STOPPING });
 
-    // Close senders, as these keep the microphone open according to browsers (and that keeps Bluetooth headphones from exiting headset mode)
-    this.state.rtcSession.connection.getSenders().forEach((sender) => {
-      sender.track.stop();
-    });
+    if (this.state.rtcSession.connection) {
+      // Close senders, as these keep the microphone open according to browsers (and that keeps Bluetooth headphones from exiting headset mode)
+      this.state.rtcSession.connection.getSenders().forEach((sender) => {
+        sender.track.stop();
+      });
+    }
 
     this.ua.terminateSessions();
   };


### PR DESCRIPTION
I've added two new props to `<SipProvider>` - incoming- and outboundAudioDeviceId. If these are passed to the SipProvider, it will use those devices for audio instead of the system default.

Please note that you **can not** change audio devices while a call is in progress, and attempting to do so will drop the call.